### PR TITLE
fix: dynamic.xyz link in accounts index

### DIFF
--- a/docs/Accounts/index.md
+++ b/docs/Accounts/index.md
@@ -16,7 +16,7 @@ tags:
 
 ### Authentication
 
-We use Dynamic.xyz[https://dynamic.xyz] for authentication, this means that you can use any of the following methods to authenticate in Fleek:
+We use [Dynamic.xyz](https://dynamic.xyz) for authentication, this means that you can use any of the following methods to authenticate in Fleek:
 
 -  Wallet Authentication
 -  Email Authentication (using OTP)


### PR DESCRIPTION
short commit to fix a link markdown mistake in the accounts section