### PR TITLE
fix: match release notes with updated blog

### DIFF
--- a/changelog/09-21-2023.md
+++ b/changelog/09-21-2023.md
@@ -23,12 +23,14 @@ In changelog we are introducing the first improvement to our closed alpha releas
 
 ### Improvements
 
-- Added ENV variables length validation, now it has a max of 150 characters
-- Added file size validation to 1GB per file
-- Fix for the redirects for invitations where users were not logged in 
-- Fix for the redirects for templates page where users were not logged in
-- Fix for the missing links in the navbar breadcrumbs
-- Fix glitching logo on templates page
-- Added suffix information for Private Gateways URL
-- Removed unnecessary redeploy option for self managed sites
-- Fixed typo in CLI go to docs link
+- Fixed site breadcrumbs to remove 304 redirect errors while navigating
+- The flow to accept an invite without having a Fleek account has been now implemented
+- When logged out and visiting the templates page, if the user logins it now redirects them this section after doing so
+- Added 150-character-max to Environment variables in sites
+- Removed the redeploy option from self-managed deployment sites
+- Fixed `Go to Docs` button typo after CLI login
+- Improved image caching and loading across the app
+- Fixed issue with Fleek logo glitching on Templates pages
+- Added extra information in the gateway for users to understand how to access their files
+- Added a 1GB per file/folder maximum size validation in storage UI
+- Fixed issue where a project’s Github app configurations were persisted even when changing projects


### PR DESCRIPTION
## Why?

Clear and short explanation here.

## How?

- Done A (replace with a breakdown of the steps)
- Done B
- Done C

## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content is linked and stored in the project
- [ ] Document filename is named after the slug
- [ ] You've reviewed spelling using a grammar checker
- [ ] For guides or references, you've tested the commands and steps
- [ ] You've done enough research before writing

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] The UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## References?

Optionally, provide references such as links

## Preview?

Optionally, provide the preview url here
