### PR TITLE
feat(docs): formatting errors and minor fixes in the CLI docs

### DIFF
--- a/docs/CLI/domains.md
+++ b/docs/CLI/domains.md
@@ -101,6 +101,12 @@ You can check the detils for the configuration of your domain at any moment, thi
 
 To do this, you can use the `domains details` method where you need to pass the domain name as a parameter. We use the domain name as an identifier for the domain to avoid using internal IDs.
 
+:::info
+
+This command might prompt you to select a listed domain.
+
+:::
+
 ```shellscript filename="Listing Domains" copy
 > fleek domains detail fleekdemos.online
 WARN! Fleek CLI is in beta, use it at your own discretion

--- a/docs/CLI/gateway.md
+++ b/docs/CLI/gateway.md
@@ -21,7 +21,7 @@ To create a private gateway you will need to have a Fleek project and a custom d
 To create a gateway using the CLI you will need to run the following command:
 
 ```shellscript filename="Creating a Gateway" copy
-> fleek gateway create
+> fleek gateways create
 ✔ Enter private gateway name (eg. first): … my-first-gateway
 > Success! Private gateway "my-first-gateway" successfully created.
 ```
@@ -29,7 +29,7 @@ To create a gateway using the CLI you will need to run the following command:
 The next step will be to configure the custom domain for your gateway. 
 
 ```shellscript filename="Configuring the custom domain" copy
-> fleek gateway domain add
+> fleek gateways domain add
 ✔ Enter private gateway name (eg. first): … my-first-gateway
 ✔ Enter domain name (eg. example.com): … ipfs.my-gateway.online
 > Success! Domain "ipfs.my-gateway.online" successfully created.   
@@ -38,7 +38,7 @@ The next step will be to configure the custom domain for your gateway.
 Now that the domain is created you will need to set up the correct DNS records to make sure that your domain points to the CDN pull zone. The CLI will provide you with the DNS records you need to add to your domain.
 
 ```shellscript  filename="Setting up the DNS records" copy
-> fleek gateway domain add
+> fleek gateways domain add
 ✔ Enter private gateway name (eg. first): … my-first-gateway
 ✔ Enter domain name (eg. example.com): … ipfs.my-gateway.online
 > Success! Domain "ipfs.my-gateway.online" successfully created.
@@ -52,7 +52,7 @@ If you need help configuring your DNS records, you can find more information in 
 Once you have confured your DNS records, you can verify your domain. To do this, you will need to press any key in the CLI. This will trigger a verification process that will check if the DNS records are correctly configured.
 
 ```shellscript filename="Finish" copy
-> fleek gateway domain add
+> fleek gateways domain add
 ✔ Enter private gateway name (eg. first): … my-first-gateway
 ✔ Enter domain name (eg. example.com): … ipfs.my-gateway.online
 > Success! Domain "ipfs.my-gateway.online" successfully created.
@@ -69,7 +69,7 @@ Now that your domain is verified, you can start using it to serve your content. 
 At any moment you can access the private gateway settings by running the following command:
 
 ```shellscript filename="Gateway settings" copy
-➜  ~ fleek gateways detail
+> fleek gateways detail
 WARN! Fleek CLI is in beta, use it at your own discretion
 ✔ Choose existing private gateway: › beefy-clever-autumn
 

--- a/docs/CLI/index.md
+++ b/docs/CLI/index.md
@@ -28,23 +28,32 @@ A CLI is a command-line program that accepts text input to execute operating sys
 
 ### Installation
 
-This package requires a minimum of Node.js 16. To install the CLI, run:
+This package requires a minimum of Node.js 18. To install the CLI, run:
 
 ```bash copy
 npm install -g @fleekxyz/cli
 ```
+
+:::info
+
+Incase this returns an access error (EACCES), run:
+```bash copy
+sudo npm install -g @fleekxyz/cli
+```
+
+:::
 
 ### Usage
 
 The Fleek CLI command has the following structure:
 
 ```bash copy
-$ fleek <service> <command> [options and parameters]
+fleek <service> <command> [options and parameters]
 ```
 
 To view all available services and commands, you can use:
 ```bash copy
-$ fleek help
+fleek help
 ```
 
 ### Authentication
@@ -52,12 +61,12 @@ $ fleek help
 All the services in the Fleek CLI require authentication. To do this, you have to run:
 
 ```bash copy
-$ fleek login
+fleek login
 ```
 This will trigger the login process, and we use Web3Auth to manage authentication. Once the flow is completed, you will be greeted like this:
 
 ```bash copy
-$ fleek login
+fleek login
 🔗 Opening browser on https://rough-truth-3196.on.fleek.xyz/login.html?verificationSession=... 
 🧑‍💻 Please login to continue
 ✅ Successfully logged in.
@@ -66,7 +75,7 @@ $ fleek login
 If at any point you want to log out, you can do so:
 
 ```bash copy
-$ fleek logout
+fleek logout
 ✅ Successfully logged out.
 ```
 
@@ -77,14 +86,14 @@ As explained [here](/docs/Projects), to interact with services, you need to have
 To create a project, you can do it like this:
 
 ```bash copy
-$ fleek projects create
+fleek projects create
 $ ? Enter project name: › 
 ```
 
 When you enter a correct name, you will be automatically switched to it. Additionally, you can switch between different projects using the 'switch' command, which will prompt a selector:
 
 ```bash copy
-$ fleek projects switch
+fleek projects switch
 ❯   project-1
     project-2
     project-3

--- a/docs/CLI/ipns.md
+++ b/docs/CLI/ipns.md
@@ -67,7 +67,7 @@ To publish an IPNS record with a CID using the CLI you need to be authenticated,
 WARN! Fleek CLI is in beta phase, use it under your own responsibility
 > IPNS record published. You can visit it here:
 https://ipfs.io/ipns/k51qzi5uqu5didozh8jmvbnowwj2d545yacagcply19yvjz8rhn0i1hrbw2thy
-WARN! IPNS propagation can take 1 up to 30 minutes.
+WARN! IPNS propagation can take up to 30 minutes.
 ```
 
 ### Resolving an IPNS record
@@ -91,7 +91,7 @@ To list all the IPNS record using the CLI you need to be authenticated, with a p
 
 ```shellscript filename="Creating an IPNS record" copy
 > fleek ipns list
-> Success! /ipfs/QmRG4xcsmoZuXqKuPz3uVBgvo3GZ6k1kLZWhmvzuKtDr9s
+
 id                         name                                                            hash                                          
 -----------------------------------------------------------------------------------------------------------------------------------------   
 clcuq190y0000jt08mpjw7pdz  k51qzi5uqu5didozh8jmvbnowwj2d545yacagcply19yvjz8rhn0i1hrbw2thy  QmRG4xcsmoZuXqKuPz3uVBgvo3GZ6k1kLZWhmvzuKtDr9s


### PR DESCRIPTION
## Why?

This PR aims to solve minor bugs and errors around the docs to make them align with the CLI output. All fixes aimed to ensure that CLI docs are aligned with the actual CLI terminal output

## How?

- in the gateway CLI docs , replaced `gateway` with `gateways`
- added info boxes for when some commands might throw error for example `sudo npm install -g @fleekxyz/cli`
- removed an incorrect output for `fleek ipns list` command

## Contribution checklist?

- [ ✔] The commit messages are detailed
- [ ✔] The `build` command runs locally
- [✔ ] Assets or static content is linked and stored in the project
- [ ✔] Document filename is named after the slug
- [✔ ] You've reviewed spelling using a grammar checker
- [✔ ] For guides or references, you've tested the commands and steps
- [ ✔] You've done enough research before writing

## Security checklist?

- [ ✔] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ✔] The UI is escaping output (to prevent XSS)
- [✔ ] Sensitive data has been identified and is being protected properly

